### PR TITLE
Fix setup-local guide: clone URL, missing prerequisites, and Linux/XAMPP DB_HOST note

### DIFF
--- a/dev/setup-local.md
+++ b/dev/setup-local.md
@@ -31,6 +31,12 @@ sudo apt-get install phpunit composer ruby ruby-dev nodejs npm
 sudo gem install sass
 ```
 
+On Debian/Ubuntu, you will also need `subversion` (used by the WordPress test installer) and the PHP `gd` and `mysqli` extensions:
+
+```
+sudo apt install subversion php-gd php-mysql -y
+```
+
 - To install WP-Cli, check [the official documentation](https://wp-cli.org/#installing).
 
 ## Setting up
@@ -40,7 +46,7 @@ First of all, clone this repository.
 Note that you can NOT clone it directly in the WordPress `plugins` directory. Clone it in a folder of its own and configure your build to point to your local WordPress `plugins` folder.
 
 ```
-git clone git@git.github.com:tainacan/tainacan.git
+git clone git@github.com:tainacan/tainacan.git
 ```
 
 Set up a WordPress installation. This could be a dedicated installation to develop Tainacan or you can use an existing instance you have. It is up to you, but you will need one, both for developing and manually testing, as well to run automated integration tests.
@@ -97,6 +103,14 @@ The parameters are:
 Inside the `tests` folder, edit the file called `bootstrap-config-sample.php` and inform the folder where you installed your WordPress Test Library. This will be `/path/to/wordpress-test-folder/wodpress-tests-lib`. Save the file as `bootstrap-config.php`.
 
 Note that the installation script will create a config file in the destination folder with your database credentials. If you have to change it, you will need to edit it there.
+
+> **Note for Linux + XAMPP users:** after running `install-wp-tests.sh`, open the generated config file at `/path/to/wordpress-test-folder/wordpress-tests-lib/wp-tests-config.php` and replace `localhost` with `127.0.0.1` in the `DB_HOST` definition:
+>
+> ```php
+> define( 'DB_HOST', '127.0.0.1' );
+> ```
+>
+> On Linux, `localhost` makes PHP connect through a Unix socket (`/var/run/mysqld/mysqld.sock`), but XAMPP uses a different socket path (`/opt/lampp/var/mysql/mysql.sock`). Using `127.0.0.1` forces a TCP connection and avoids the issue.
 
 You only need to do all this once, and now you are ready to run tests.
 

--- a/es-mx/dev/setup-local.md
+++ b/es-mx/dev/setup-local.md
@@ -31,6 +31,12 @@ sudo apt-get install phpunit composer ruby ruby-dev nodejs npm
 sudo gem install sass
 ```
 
+En Debian/Ubuntu, también necesitarás `subversion` (utilizado por el instalador de pruebas de WordPress) y las extensiones de PHP `gd` y `mysqli`:
+
+```
+sudo apt install subversion php-gd php-mysql -y
+```
+
 - Para instalar WP-Cli, visita [la documentación oficial](https://wp-cli.org/#installing).
 
 ## Configuración
@@ -40,7 +46,7 @@ En primer lugar, clone este repositorio.
 Ten en cuenta que NO puedes clonarlo directamente en el directorio `plugins` de WordPress. Clónelo en una carpeta propia y configure su compilación para que apunte a su carpeta local de `plugins` de WordPress.
 
 ```
-git clone git@git.github.com:tainacan/tainacan.git
+git clone git@github.com:tainacan/tainacan.git
 ```
 
 Configura una instalación de WordPress. Puede ser una instalación dedicada para desarrollar Tainacan o puedes usar una instancia existente que tengas. Depende de ti, pero necesitarás una, tanto para desarrollar y probar manualmente, como para ejecutar pruebas de integración automatizadas.
@@ -97,6 +103,14 @@ Los parámetros son:
 Dentro de la carpeta `tests`, edite el archivo llamado `bootstrap-config-sample.php` e informe la carpeta donde instaló su Librería de Pruebas de WordPress. Esta será `/path/to/wordpress-test-folder/wodpress-tests-lib`. Guarde el archivo como `bootstrap-config.php`.
 
 Ten en cuenta que el script de instalación creará un archivo de configuración en la carpeta de destino con tus credenciales de la base de datos. Si tienes que cambiarlo, tendrás que editarlo allí.
+
+> **Nota para usuarios de Linux + XAMPP:** después de ejecutar `install-wp-tests.sh`, abre el archivo de configuración generado en `/path/to/wordpress-test-folder/wordpress-tests-lib/wp-tests-config.php` y reemplaza `localhost` por `127.0.0.1` en la definición de `DB_HOST`:
+>
+> ```php
+> define( 'DB_HOST', '127.0.0.1' );
+> ```
+>
+> En Linux, `localhost` hace que PHP se conecte a través de un socket Unix (`/var/run/mysqld/mysqld.sock`), pero XAMPP utiliza una ruta de socket diferente (`/opt/lampp/var/mysql/mysql.sock`). Usar `127.0.0.1` fuerza una conexión TCP y evita el problema.
 
 Sólo tienes que hacer todo esto una vez, y ya estás listo para ejecutar pruebas.
 


### PR DESCRIPTION
Fixes three issues in `dev/setup-local.md` that prevented new contributors from completing the local environment setup on Linux (also applied to the `es-mx` translation).

- Corrects the `git clone` URL (`git@git.github.com:` → `git@github.com:`)
- Adds missing prerequisites for the test setup: `subversion`, `php-gd`, and `php-mysql`
- Adds a note for Linux + XAMPP users about replacing `localhost` with `127.0.0.1` in `wp-tests-config.php` to avoid Unix socket connection failures

**Changes**:
  - `dev/setup-local.md`
  - `es-mx/dev/setup-local.md`


Closed #60 